### PR TITLE
Invert conditional for loading frames into buffer

### DIFF
--- a/CoreAudioPlayer/CoreAudioPlayer/SoundController.c
+++ b/CoreAudioPlayer/CoreAudioPlayer/SoundController.c
@@ -177,7 +177,7 @@ void CAPLoadAudioPlayer(CFURLRef url, CAPAudioPlayer * audioPlayer) {
     UInt32 readFrames = 0;
     while (readFrames < fileLengthInFrames) {
         UInt32 framesLeftToRead = (UInt32)fileLengthInFrames - readFrames;
-        UInt32 framesToRead = (16384 < framesLeftToRead) ? framesLeftToRead : 16384;
+        UInt32 framesToRead = (framesLeftToRead < 16384) ? framesLeftToRead : 16384;
         
         // Set the scratch buffer to point to the correct position on the real buffer
         scratchBufferList->mNumberBuffers = bufferList->mNumberBuffers;


### PR DESCRIPTION
This line was causing my app to crash on device.  Inverting the conditinal seems to have fixed it.

Talking with James about the significiance of `16384`:
`16384 was taken from some other source code I found, its 2 the power of 17 so must be some sort of memory chunk...`